### PR TITLE
Build, test with and include plain-old chromdriver 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ compatible with the version `robotlab` was built with: as of writing, `0.35.x`.
 All of the dependencies are captured in [construct.yaml.in][]. In addition to
 everything mentioned above, you'll also find:
 
-In addition, to support the workshop, a number of libraries are included:
+In addition to required dependencies a number of extra libraries are included to
+showcase some of the features of using Robot Framework interactively.
 - `SeleniumLibrary` for controlling browsers
-  - `geckodriver` for interacting with Firefox
-  - `python-chromedriver-binary` for interacting with Chrome & Chromium
-  - > Note: it's pretty easy to get `webdriver` for Edge, but can't be redistributed
-- `opencv` for doing image-driven testing
-- `robotframework-lint` for normalizing your robot syntax
+  - `geckodriver` for interacting with Mozilla Firefox
+  - `chromedriver` for interacting with Chromium and Google Chrome
+  - > it's pretty easy to [get `webdriver`][webdriver] for Microsoft Edge, but
+      can't be redistributed
+- `opencv` for image-driven testing
+- `robotframework-lint` for helping you write clean robot syntax
 
 
 [anaconda-project]: https://github.com/anaconda-platform/anaconda-project
@@ -84,3 +86,4 @@ In addition, to support the workshop, a number of libraries are included:
 [labextensions]: https://www.npmjs.com/search?q=keywords:jupyterlab-extension
 [Miniconda]: https://conda.io/miniconda.html
 [robotkernel]: https://github.com/datakurre/robotkernel
+[webdriver]: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads

--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -5,6 +5,10 @@ commands:
     unix: python -m scripts.build
     env_spec: _build
 
+  chromedriver:
+    unix: conda install -v ${PROJECT_DIR}/_artifacts/conda-bld/linux-64/chromedriver*
+    env_spec: _build
+
   lint:
     unix: python -m scripts.lint
     env_spec: _build
@@ -81,7 +85,6 @@ env_specs:
     - flake8
     - geckodriver
     - python >=3.6,<3.7
-    - python-chromedriver-binary
     - robotframework
     - robotframework-lint
     - robotframework-seleniumlibrary

--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -6,8 +6,20 @@ commands:
     env_spec: _build
 
   chromedriver:
-    unix: conda install -v ${PROJECT_DIR}/_artifacts/conda-bld/linux-64/chromedriver*
+    unix: >
+      conda install -fv ${PROJECT_DIR}/_artifacts/conda-bld/linux-64/chromedriver-*.tar.bz2
+      && chromedriver --version
     env_spec: _build
+
+  chromedriver:win:
+    windows: >
+      @ECHO ON
+      && cd _artifacts
+      && cd conda-bld
+      && cd win-64
+      && set PKG=chromedriver-*
+      && %PKG%
+    env_spec: _build_win
 
   lint:
     unix: python -m scripts.lint

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,16 +3,19 @@ jobs:
   parameters:
     name: Linux
     vmImage: ubuntu-16.04
+    condaPlatform: linux-64
 
 - template: ci/job.robotlab.yml
   parameters:
     name: MacOSX
     vmImage: macos-10.13
+    condaPlatform: osx-64
 
 - template: ci/job.robotlab.yml
   parameters:
     name: Windows
     vmImage: vs2017-win2016
+    condaPlatform: win-64
 
 variables:
   MINICONDA_VERSION: 4.5.4

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,19 +3,16 @@ jobs:
   parameters:
     name: Linux
     vmImage: ubuntu-16.04
-    condaPlatform: linux-64
 
 - template: ci/job.robotlab.yml
   parameters:
     name: MacOSX
     vmImage: macos-10.13
-    condaPlatform: osx-64
 
 - template: ci/job.robotlab.yml
   parameters:
     name: Windows
     vmImage: vs2017-win2016
-    condaPlatform: win-64
 
 variables:
   MINICONDA_VERSION: 4.5.4

--- a/ci/job.robotlab.yml
+++ b/ci/job.robotlab.yml
@@ -1,7 +1,6 @@
 parameters:
   name: Linux
   vmImage: ubuntu-16.04
-  condaSubdir: linux-64
 
 jobs:
   - job: ${{ parameters.name }}
@@ -22,4 +21,3 @@ jobs:
       - template: steps.common.yml
         parameters:
           name: ${{ parameters.name }}
-          condaSubdir: ${{ condaSubdir }}

--- a/ci/job.robotlab.yml
+++ b/ci/job.robotlab.yml
@@ -17,6 +17,8 @@ jobs:
           displayName: Install Browsers
 
       - template: steps.conda.yml
+        parameters:
+          name: ${{ parameters.name }}
 
       - template: steps.common.yml
         parameters:

--- a/ci/job.robotlab.yml
+++ b/ci/job.robotlab.yml
@@ -16,11 +16,6 @@ jobs:
             && brew cask install firefox
           displayName: Install Browsers on MacOSX
 
-      - ${{ if eq(parameters.name, 'Windows') }}:
-        - script: >
-            choco install googlechrome --yes --install-arguments '"/l*v c:\googlechrome.log"' || more c:\googlechrome.log
-          displayName: Install Browsers on Windows
-
       - template: steps.conda.yml
         parameters:
           name: ${{ parameters.name }}

--- a/ci/job.robotlab.yml
+++ b/ci/job.robotlab.yml
@@ -14,11 +14,11 @@ jobs:
             brew tap caskroom/cask \
             && brew cask install google-chrome \
             && brew cask install firefox
-          displayName: Install Browsers
+          displayName: Install Browsers on MacOSX
 
       - ${{ if eq(parameters.name, 'Windows') }}:
-        - script: choco install googlechrome -y
-          displayName: Install Browsers
+        - script: choco install googlechrome --yes --verbose --force
+          displayName: Install Browsers on Windows
 
       - template: steps.conda.yml
         parameters:

--- a/ci/job.robotlab.yml
+++ b/ci/job.robotlab.yml
@@ -17,7 +17,7 @@ jobs:
           displayName: Install Browsers on MacOSX
 
       - ${{ if eq(parameters.name, 'Windows') }}:
-        - script: choco install googlechrome --yes --verbose --force
+        - script: choco install googlechrome --yes --install-arguments '"/l*v msi_install.log"' || more msi_install.log
           displayName: Install Browsers on Windows
 
       - template: steps.conda.yml

--- a/ci/job.robotlab.yml
+++ b/ci/job.robotlab.yml
@@ -16,6 +16,10 @@ jobs:
             && brew cask install firefox
           displayName: Install Browsers
 
+      - ${{ if eq(parameters.name, 'Windows') }}:
+        - script: choco install googlechrome -y
+          displayName: Install Browsers
+
       - template: steps.conda.yml
         parameters:
           name: ${{ parameters.name }}

--- a/ci/job.robotlab.yml
+++ b/ci/job.robotlab.yml
@@ -22,3 +22,4 @@ jobs:
       - template: steps.common.yml
         parameters:
           name: ${{ parameters.name }}
+          condaSubdir: ${{ condaSubdir }}

--- a/ci/job.robotlab.yml
+++ b/ci/job.robotlab.yml
@@ -17,7 +17,8 @@ jobs:
           displayName: Install Browsers on MacOSX
 
       - ${{ if eq(parameters.name, 'Windows') }}:
-        - script: choco install googlechrome --yes --install-arguments '"/l*v msi_install.log"' || more msi_install.log
+        - script: >
+            choco install googlechrome --yes --install-arguments '"/l*v c:\googlechrome.log"' || more c:\googlechrome.log
           displayName: Install Browsers on Windows
 
       - template: steps.conda.yml

--- a/ci/job.robotlab.yml
+++ b/ci/job.robotlab.yml
@@ -1,6 +1,7 @@
 parameters:
   name: Linux
   vmImage: ubuntu-16.04
+  condaSubdir: linux-64
 
 jobs:
   - job: ${{ parameters.name }}

--- a/ci/steps.chromedriver.yml
+++ b/ci/steps.chromedriver.yml
@@ -1,0 +1,32 @@
+parameters:
+  name: Linux
+
+steps:
+  - script: >
+      python -m scripts.build conda
+      chromedriver
+    displayName: Build ChromeDriver
+
+  - ${{ if eq(parameters.name, 'Windows') }}:
+      - task: CondaEnvironment@1
+        inputs:
+          installOptions: -fv
+          packageSpecs: _artifacts\conda-bld\win-64\chromedriver*
+        displayName: Install ChromeDriver on Windows
+
+  - ${{ if eq(parameters.name, 'MacOSX') }}:
+      - task: CondaEnvironment@1
+        inputs:
+          installOptions: -fv
+          packageSpecs:  _artifacts/conda-bld/osx-64/chromedriver*
+        displayName: Install ChromeDriver on OSX
+
+  - ${{ if eq(parameters.name, 'Linux') }}:
+      - task: CondaEnvironment@1
+        inputs:
+          installOptions: -fv
+          packageSpecs:  _artifacts/conda-bld/linux-64/chromedriver*
+        displayName: Install ChromeDriver on Linux
+
+  - script: chromedriver --version
+    displayName: Verify ChromeDriver

--- a/ci/steps.chromedriver.yml
+++ b/ci/steps.chromedriver.yml
@@ -8,7 +8,7 @@ steps:
     displayName: Build ChromeDriver
 
   - ${{ if eq(parameters.name, 'Windows') }}:
-      - script: conda install -v _artifacts\conda-bld\win-64\chromedriver*
+      - script: "conda install -v _artifacts\\conda-bld\\win-64\\chromedriver*"
         displayName: Install ChromeDriver on Windows
 
   - ${{ if eq(parameters.name, 'MacOSX') }}:

--- a/ci/steps.chromedriver.yml
+++ b/ci/steps.chromedriver.yml
@@ -13,7 +13,6 @@ steps:
           && cd conda-bld
           && cd win-64
           && conda install -fv chromedriver-2.44-0.tar.bz2
-          && echo %PATH%
           && chromedriver.exe --version
         displayName: Install ChromeDriver on Windows
 

--- a/ci/steps.chromedriver.yml
+++ b/ci/steps.chromedriver.yml
@@ -13,15 +13,18 @@ steps:
           && cd conda-bld
           && cd win-64
           && conda install -fv chromedriver-2.44-0.tar.bz2
+          && echo %PATH%
+          && chromedriver.exe --version
         displayName: Install ChromeDriver on Windows
 
   - ${{ if eq(parameters.name, 'MacOSX') }}:
-      - script: conda install -fv _artifacts/conda-bld/osx-64/chromedriver-*.tar.bz2
+      - script: >
+          conda install -fv _artifacts/conda-bld/osx-64/chromedriver-*.tar.bz2
+          && chromedriver --version
         displayName: Install ChromeDriver on OSX
 
   - ${{ if eq(parameters.name, 'Linux') }}:
-      - script: conda install -v _artifacts/conda-bld/linux-64/chromedriver-*.tar.bz2
+      - script: >
+          conda install -v _artifacts/conda-bld/linux-64/chromedriver-*.tar.bz2
+          && chromedriver --version
         displayName: Install ChromeDriver on Linux
-
-  - script: chromedriver --version
-    displayName: Verify ChromeDriver

--- a/ci/steps.chromedriver.yml
+++ b/ci/steps.chromedriver.yml
@@ -8,24 +8,15 @@ steps:
     displayName: Build ChromeDriver
 
   - ${{ if eq(parameters.name, 'Windows') }}:
-      - task: CondaEnvironment@1
-        inputs:
-          installOptions: -fv
-          packageSpecs: _artifacts\conda-bld\win-64\chromedriver*
+      - script: conda install -v _artifacts\conda-bld\win-64\chromedriver*
         displayName: Install ChromeDriver on Windows
 
   - ${{ if eq(parameters.name, 'MacOSX') }}:
-      - task: CondaEnvironment@1
-        inputs:
-          installOptions: -fv
-          packageSpecs:  _artifacts/conda-bld/osx-64/chromedriver*
+      - script: conda install -v _artifacts/conda-bld/osx-64/chromedriver*
         displayName: Install ChromeDriver on OSX
 
   - ${{ if eq(parameters.name, 'Linux') }}:
-      - task: CondaEnvironment@1
-        inputs:
-          installOptions: -fv
-          packageSpecs:  _artifacts/conda-bld/linux-64/chromedriver*
+      - script: conda install -v _artifacts/conda-bld/linux-64/chromedriver*
         displayName: Install ChromeDriver on Linux
 
   - script: chromedriver --version

--- a/ci/steps.chromedriver.yml
+++ b/ci/steps.chromedriver.yml
@@ -12,15 +12,15 @@ steps:
           cd _artifacts
           && cd conda-bld
           && cd win-64
-          && conda install -v chromedriver*
+          && conda install -fv chromedriver-2.44-0.tar.bz2
         displayName: Install ChromeDriver on Windows
 
   - ${{ if eq(parameters.name, 'MacOSX') }}:
-      - script: conda install -v _artifacts/conda-bld/osx-64/chromedriver*
+      - script: conda install -fv _artifacts/conda-bld/osx-64/chromedriver-*.tar.bz2
         displayName: Install ChromeDriver on OSX
 
   - ${{ if eq(parameters.name, 'Linux') }}:
-      - script: conda install -v _artifacts/conda-bld/linux-64/chromedriver*
+      - script: conda install -v _artifacts/conda-bld/linux-64/chromedriver-*.tar.bz2
         displayName: Install ChromeDriver on Linux
 
   - script: chromedriver --version

--- a/ci/steps.chromedriver.yml
+++ b/ci/steps.chromedriver.yml
@@ -8,7 +8,11 @@ steps:
     displayName: Build ChromeDriver
 
   - ${{ if eq(parameters.name, 'Windows') }}:
-      - script: "conda install -v _artifacts\\conda-bld\\win-64\\chromedriver*"
+      - script: >
+          cd _artifacts
+          && cd conda-bld
+          && cd win-64
+          && conda install -v chromedriver*
         displayName: Install ChromeDriver on Windows
 
   - ${{ if eq(parameters.name, 'MacOSX') }}:

--- a/ci/steps.common.yml
+++ b/ci/steps.common.yml
@@ -12,20 +12,23 @@ steps:
       robotlab
     displayName: Build Conda Packages
 
-  - script: python -m scripts.build constructor
-    displayName: Build Constructor
-
   - ${{ if eq(parameters.name, 'Windows') }}:
-      script: conda install -v _artifacts\conda-bld\win-64\chromedriver*
-      displayName: Install ChromeDriver on Windows
+      - script: conda install -v _artifacts\conda-bld\win-64\chromedriver*
+        displayName: Install ChromeDriver on Windows
 
   - ${{ if eq(parameters.name, 'MacOSX') }}:
-      script: conda install -v _artifacts/conda-bld/osx-64/chromedriver*
-      displayName: Install ChromeDriver on OSX
+      - script: conda install -v _artifacts/conda-bld/osx-64/chromedriver*
+        displayName: Install ChromeDriver on OSX
 
   - ${{ if eq(parameters.name, 'Linux') }}:
-      script: conda install -v _artifacts/conda-bld/linux-64/chromedriver*
-      displayName: Install ChromeDriver on Linux
+      - script: conda install -v _artifacts/conda-bld/linux-64/chromedriver*
+        displayName: Install ChromeDriver on Linux
+
+  - script: chromedriver --version
+    displayName: Verify ChromeDriver
+
+  - script: python -m scripts.build constructor
+    displayName: Build Constructor
 
   - script: python -m scripts.test
     displayName: Test

--- a/ci/steps.common.yml
+++ b/ci/steps.common.yml
@@ -16,13 +16,13 @@ steps:
   - script: python -m scripts.build constructor
     displayName: Build Constructor
 
-  - script: >
-      cd _artifacts
-      && cd conda-bld
-      && cd {{ condaSubdir }}
-      && conda install -v chromedriver*
-      && chromedriver --version
-    displayName: Install ChromeDriver
+  - ${{ if eq(parameters.name, 'Windows') }}:
+      script: conda install -v _artifacts\conda-bld\win-64\chromedriver*
+      displayName: Install ChromeDriver
+
+  - ${{ if not(eq(parameters.name, 'Windows')) }}:
+      script: conda install -v _artifacts/conda-bld/$CONDASUBDIR/chromedriver*
+      displayName: Install ChromeDriver
 
   - script: python -m scripts.test
     displayName: Test

--- a/ci/steps.common.yml
+++ b/ci/steps.common.yml
@@ -4,13 +4,8 @@ parameters:
 steps:
   - script: >
       python -m scripts.build conda
-      lunr
-      robotframework
-      robotframework-lint
-      robotframework-seleniumlibrary
-      robotkernel
-      robotlab
-    displayName: Build Conda Packages
+      chromedriver
+    displayName: Build ChromeDriver
 
   - ${{ if eq(parameters.name, 'Windows') }}:
       - script: conda install -v _artifacts\conda-bld\win-64\chromedriver*
@@ -26,6 +21,16 @@ steps:
 
   - script: chromedriver --version
     displayName: Verify ChromeDriver
+
+  - script: >
+      python -m scripts.build conda
+      lunr
+      robotframework
+      robotframework-lint
+      robotframework-seleniumlibrary
+      robotkernel
+      robotlab
+    displayName: Build Conda Packages
 
   - script: python -m scripts.build constructor
     displayName: Build Constructor

--- a/ci/steps.common.yml
+++ b/ci/steps.common.yml
@@ -2,25 +2,9 @@ parameters:
   name: Linux
 
 steps:
-  - script: >
-      python -m scripts.build conda
-      chromedriver
-    displayName: Build ChromeDriver
-
-  - ${{ if eq(parameters.name, 'Windows') }}:
-      - script: conda install -v _artifacts\conda-bld\win-64\chromedriver*
-        displayName: Install ChromeDriver on Windows
-
-  - ${{ if eq(parameters.name, 'MacOSX') }}:
-      - script: conda install -v _artifacts/conda-bld/osx-64/chromedriver*
-        displayName: Install ChromeDriver on OSX
-
-  - ${{ if eq(parameters.name, 'Linux') }}:
-      - script: conda install -v _artifacts/conda-bld/linux-64/chromedriver*
-        displayName: Install ChromeDriver on Linux
-
-  - script: chromedriver --version
-    displayName: Verify ChromeDriver
+  - template: steps.chromedriver.yml
+    parameters:
+      name: ${{ parameters.name }}
 
   - script: >
       python -m scripts.build conda

--- a/ci/steps.common.yml
+++ b/ci/steps.common.yml
@@ -1,6 +1,5 @@
 parameters:
   name: Linux
-  condaSubdir: linux-64
 
 steps:
   - script: >
@@ -18,11 +17,15 @@ steps:
 
   - ${{ if eq(parameters.name, 'Windows') }}:
       script: conda install -v _artifacts\conda-bld\win-64\chromedriver*
-      displayName: Install ChromeDriver
+      displayName: Install ChromeDriver on Windows
 
-  - ${{ if not(eq(parameters.name, 'Windows')) }}:
-      script: conda install -v _artifacts/conda-bld/$CONDASUBDIR/chromedriver*
-      displayName: Install ChromeDriver
+  - ${{ if eq(parameters.name, 'MacOSX') }}:
+      script: conda install -v _artifacts/conda-bld/osx-64/chromedriver*
+      displayName: Install ChromeDriver on OSX
+
+  - ${{ if eq(parameters.name, 'Linux') }}:
+      script: conda install -v _artifacts/conda-bld/linux-64/chromedriver*
+      displayName: Install ChromeDriver on Linux
 
   - script: python -m scripts.test
     displayName: Test

--- a/ci/steps.common.yml
+++ b/ci/steps.common.yml
@@ -1,5 +1,6 @@
 parameters:
-  name: Windows
+  name: Linux
+  condaSubdir: linux-64
 
 steps:
   - script: >
@@ -14,6 +15,14 @@ steps:
 
   - script: python -m scripts.build constructor
     displayName: Build Constructor
+
+  - script: >
+      cd _artifacts
+      && cd conda-bld
+      && cd {{ condaSubdir }}
+      && conda install -v chromedriver*
+      && chromedriver --version
+    displayName: Install ChromeDriver
 
   - script: python -m scripts.test
     displayName: Test

--- a/ci/steps.conda.yml
+++ b/ci/steps.conda.yml
@@ -3,6 +3,7 @@ steps:
     inputs:
       installOptions: -c defaults -c conda-forge
       createCustomEnvironment: true
+      environmentName: _robots_from_jupyter
       packageSpecs: >
         conda>=4.5.11,<4.6
         conda-build>=3.15,<3.16

--- a/ci/steps.conda.yml
+++ b/ci/steps.conda.yml
@@ -14,3 +14,6 @@ steps:
         python>=3.6,<3.7
         robotframework
         robotframework-seleniumlibrary
+  - ${{ if not(eq(parameters.name, 'Windows')) }}:
+    - script: sudo chown -R 1001:999 /usr/envs/_robots_from_jupyter
+      displayName: Fix Conda env permissions

--- a/ci/steps.conda.yml
+++ b/ci/steps.conda.yml
@@ -1,7 +1,7 @@
 steps:
   - task: CondaEnvironment@1
     inputs:
-      installOptions: -c conda-forge -c defaults
+      installOptions: -c defaults -c conda-forge
       packageSpecs: >
         conda>=4.5.11,<4.6
         conda-build>=3.15,<3.16

--- a/ci/steps.conda.yml
+++ b/ci/steps.conda.yml
@@ -14,6 +14,9 @@ steps:
         python>=3.6,<3.7
         robotframework
         robotframework-seleniumlibrary
-  - ${{ if not(eq(parameters.name, 'Windows')) }}:
-    - script: sudo chown -R 1001:999 /usr/envs/_robots_from_jupyter
-      displayName: Fix Conda env permissions
+  - ${{ if eq(parameters.name, 'Linux') }}:
+    - script: sudo chown -R $UID /usr/envs/_robots_from_jupyter
+      displayName: Fix Conda env permissions on Linux
+  - ${{ if eq(parameters.name, 'MacOSX') }}:
+    - script: sudo chown -R $UID /usr/local/miniconda/envs/_robots_from_jupyter
+      displayName: Fix Conda env permissions on MacOSX

--- a/ci/steps.conda.yml
+++ b/ci/steps.conda.yml
@@ -1,8 +1,9 @@
 steps:
   - task: CondaEnvironment@1
     inputs:
-      installOptions: -c defaults -c conda-forge
+      createOptions: -c defaults -c conda-forge
       createCustomEnvironment: true
+      updateConda: false
       environmentName: _robots_from_jupyter
       packageSpecs: >
         conda>=4.5.11,<4.6

--- a/ci/steps.conda.yml
+++ b/ci/steps.conda.yml
@@ -2,6 +2,7 @@ steps:
   - task: CondaEnvironment@1
     inputs:
       installOptions: -c defaults -c conda-forge
+      createCustomEnvironment: true
       packageSpecs: >
         conda>=4.5.11,<4.6
         conda-build>=3.15,<3.16

--- a/ci/steps.conda.yml
+++ b/ci/steps.conda.yml
@@ -9,6 +9,5 @@ steps:
         constructor
         geckodriver
         python>=3.6,<3.7
-        python-chromedriver-binary
         robotframework
         robotframework-seleniumlibrary

--- a/constructor/construct.yaml.in
+++ b/constructor/construct.yaml.in
@@ -14,8 +14,7 @@ specs:
   - nodejs >={{ node_min }},<{{ node_max }}
   - opencv
   - python >={{ py_min }},<{{ py_max }}
-  - python-chromedriver-binary
-  - python-chromedriver-binary
+  - chromedriver
   - robotframework =={{ rf_version }}
   - robotframework-lint
   - robotframework-seleniumlibrary

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,6 @@ dependencies:
   - flake8
   - geckodriver
   - python >=3.6,<3.7
-  - python-chromedriver-binary
   - robotframework
   - robotframework-lint
   - robotframework-seleniumlibrary

--- a/recipes/chromedriver/BSD-3-Clause.txt
+++ b/recipes/chromedriver/BSD-3-Clause.txt
@@ -1,0 +1,27 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/chromedriver/meta.yaml
+++ b/recipes/chromedriver/meta.yaml
@@ -16,7 +16,7 @@ build:
   number: 0
   script:
     - mv {{ name }} $PREFIX/bin/  # [unix]
-    - move {{ name }}.exe %SCRIPTS%\  # [win]
+    - move {{ name }}.exe %LIBRARY_BIN%\  # [win]
 
 requirements:
   host:

--- a/recipes/chromedriver/meta.yaml
+++ b/recipes/chromedriver/meta.yaml
@@ -1,0 +1,36 @@
+package:
+  name: {% set name = "chromedriver" %}{{ name }}
+  version: {% set version = "2.44" %}{{ version }}
+
+source:
+  url: https://{{ name }}.storage.googleapis.com/{{ version }}/{{ name }}_linux64.zip  # [linux]
+  sha256: 687d2e15c42908e2911344c08a949461b3f20a83017a7a682ef4d002e05b5d46  # [linux]
+
+  url: https://{{ name }}.storage.googleapis.com/{{ version }}/{{ name }}_mac64.zip  # [osx]
+  sha256: 3fd49c2782a5f93cb48ff2dee021004d9a7fb393798e4c4807b391cedcd30ed9  # [osx]
+
+  url: https://{{ name }}.storage.googleapis.com/{{ version }}/{{ name }}_win32.zip  # [win]
+  sha256: 5d2d2ddb2ed3730672484160c822b75b41c4e77f9cadb5111530699d561c548c  # [win]
+
+build:
+  number: 0
+  script:
+    - mv {{ name }} $PREFIX/bin/  # [unix]
+    - move {{ name }}.exe %SCRIPTS%\  # [win]
+
+requirements:
+  host:
+  run:
+test:
+  commands:
+    - chromedriver --version
+    - chromedriver --help
+
+about:
+  home: http://chromedriver.chromium.org
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: {{ environ['RECIPE_DIR'] }}/BSD-3-Clause.txt
+  summary: >
+    ChromeDriver is a standalone server which implements WebDriver's wire
+    protocol for Chromium.

--- a/recipes/chromedriver/meta.yaml
+++ b/recipes/chromedriver/meta.yaml
@@ -16,7 +16,7 @@ build:
   number: 0
   script:
     - mv {{ name }} $PREFIX/bin/  # [unix]
-    - move {{ name }}.exe %LIBRARY_BIN%\  # [win]
+    - move {{ name }}.exe %SCRIPTS%\  # [win]
 
 requirements:
   host:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -19,11 +19,13 @@ from . import (
 )
 
 
-def build_conda(packages=None):
+def build_conda(packages=None, force=False):
     """ Build some packages (mostly re-arching conda-forge `noarch: python`)
     """
 
-    if not packages:
+    if packages:
+        force = True
+    else:
         packages = ["."]
 
     for package in packages:
@@ -41,10 +43,9 @@ def build_conda(packages=None):
                 "https://repo.anaconda.com/pkgs/free",
                 "-c",
                 "https://conda.anaconda.org/conda-forge",
-                "--skip-existing",
                 "--python",
                 PY_MIN,
-            ],
+            ] + ([] if force else ["--skip-existing"]),
             cwd=str(RECIPE_DIR),
         )
         if rc:

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -2,9 +2,6 @@ from . import run, TEST_DIR, TEST_OUT
 import sys
 import platform
 
-# XXX: This adds the bundled chromdriver to the path as a side-effect
-import chromedriver_binary  # noqa
-
 
 def test():
     return run(

--- a/tests/resources/Shell.robot
+++ b/tests/resources/Shell.robot
@@ -3,6 +3,7 @@ Documentation     Interact with the RobotLab ne JupyterLab application shell
 Library           BuiltIn
 Library           SeleniumLibrary
 Library           OperatingSystem
+Resource          Skip.robot
 
 *** Variables ***
 ${CELL_CSS}       .jp-Notebook .jp-Cell:last-of-type .jp-InputArea-editor .CodeMirror
@@ -21,6 +22,8 @@ ${DOCK}           //div[@id='jp-main-dock-panel']
 Open RobotLab
     [Arguments]    ${browser}
     [Documentation]    Start RobotLab in a browser
+    Set Test Variable    ${BROWSER}    ${browser}
+    Maybe Skip
     Should Not Be Empty    ${LAB URL}    msg=Needs a configured RobotLab server
     Open Browser    ${LAB URL}    ${browser}
     Wait for Splash Screen
@@ -66,5 +69,6 @@ Execute JupyterLab Command
 
 Reset Application State and Close
     [Documentation]    Try to clean up after doing some things to the JupyterLab state
+    Maybe Skip
     Execute JupyterLab Command    Reset Application State
     Close Browser

--- a/tests/resources/Skip.robot
+++ b/tests/resources/Skip.robot
@@ -1,0 +1,4 @@
+*** Keywords ***
+Maybe Skip
+    Run Keyword If    "${PLATFORM}" == "win32" and "${BROWSER}" == "headlesschrome"
+    ...  Pass Execution  because Chrome is too old on Azure  skip:chrome-on-windows


### PR DESCRIPTION
The previous chromedriver approach was kinda weird. This makes it more normal, but introduces a dependency between our build chain and our test rig. So it goes!

TODO: submit recipe to conda-forge.