### PR TITLE
Re-add chromedriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ showcase some of the features of using Robot Framework interactively.
 - `JupyterLibrary` for testing Jupyter clients with robotframework
   - `SeleniumLibrary` for controlling browsers
     - `geckodriver` for interacting with Mozilla Firefox
-    - `python-chromedriver-binary` for interacting with Chromium and Google Chrome
+    - `chromedriver` for interacting with Chromium and Google Chrome
     - > it's pretty easy to [get `webdriver`][webdriver] for Microsoft Edge, but
         can't be redistributed
 - `opencv` for image-driven testing

--- a/ci/steps.common.yml
+++ b/ci/steps.common.yml
@@ -8,6 +8,7 @@ steps:
   - script: >
       python -m scripts.build conda
       pyshortcuts
+      chromedriver
       jsonpointer
       rfc3987
       jsonpath-ng

--- a/constructor/construct.yaml.in
+++ b/constructor/construct.yaml.in
@@ -17,7 +17,7 @@ specs:
   - opencv
   - pyshortcuts
   - python >={{ py_min }},<{{ py_max }}
-  - python-chromedriver-binary =={{ cd_version }}
+  - chromedriver =={{ cd_version }}
   - restinstance
   - robotframework =={{ rf_version }}
   - robotframework-jupyterlibrary

--- a/recipes/chromedriver/BSD-3-Clause.txt
+++ b/recipes/chromedriver/BSD-3-Clause.txt
@@ -1,0 +1,27 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/chromedriver/meta.yaml
+++ b/recipes/chromedriver/meta.yaml
@@ -1,0 +1,37 @@
+package:
+  name: {% set name = "chromedriver" %}{{ name }}
+  version: {% set version = "2.45" %}{{ version }}
+
+source:
+  url: https://{{ name }}.storage.googleapis.com/{{ version }}/{{ name }}_linux64.zip  # [linux]
+  sha256: d4a5eec0a3b7fec9bcb71353233dde38630e51b29fa7b218cdd196e2e4487da7  # [linux]
+
+  url: https://{{ name }}.storage.googleapis.com/{{ version }}/{{ name }}_mac64.zip  # [osx]
+  sha256: aa0f416a48e20185da62525869c1f98f994bf99f241d6ce2eb1af6ceb517c425  # [osx]
+
+  url: https://{{ name }}.storage.googleapis.com/{{ version }}/{{ name }}_win32.zip  # [win]
+  sha256: 8f3373a260a524410e25ea643ecb0175ed49a078088c7ab4d88db323ee19a230  # [win]
+
+build:
+  number: 0
+  script:
+    - mv {{ name }} $PREFIX/bin/  # [unix]
+    - move {{ name }}.exe %SCRIPTS%\  # [win]
+
+requirements:
+  host: []
+  run: []
+
+test:
+  commands:
+    - chromedriver --version
+    - chromedriver --help
+
+about:
+  home: http://chromedriver.chromium.org
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: {{ environ['RECIPE_DIR'] }}/BSD-3-Clause.txt
+  summary: >
+    ChromeDriver is a standalone server which implements WebDriver's wire
+    protocol for Chromium.


### PR DESCRIPTION
The latest `python-chromedriver-binary` from `conda-forge` is [busted on windows](https://github.com/conda-forge/python-chromedriver-binary-feedstock/issues/12), so let's go back to building the raw binary for packaging.

Still using the conda-forge ones in test, because luckily the chrome version on azure is old, so it still works. So we still have the janky path hack in place. sigh.