### PR TITLE
Fix importing of launch

### DIFF
--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -44,7 +44,7 @@ commands:
 
   robotlab:launch:
     env_spec: robotlab-dev
-    unix: python -m robotlab.launch
+    unix: python ./robotlab/src/robotlab/launch.py
 
   robotlab:launch:win:
     env_spec: robotlab-dev-win

--- a/ci/steps.common.yml
+++ b/ci/steps.common.yml
@@ -14,6 +14,7 @@ steps:
       jsonpath-ng
       flex-swagger
       robotframework
+      robotframeworklexer
       robotframework-lint
       robotframework-seleniumlibrary
       restinstance

--- a/constructor/construct.yaml.in
+++ b/constructor/construct.yaml.in
@@ -26,6 +26,7 @@ specs:
   - robotframework-seleniumscreenshots
   - robotkernel =={{ version }}
   - robotlab =={{ version }}
+  {% if platform == "darwin" %}- python.app{% endif %}
 
 install_in_dependency_order: True
 

--- a/constructor/construct.yaml.in
+++ b/constructor/construct.yaml.in
@@ -24,6 +24,7 @@ specs:
   - robotframework-lint
   - robotframework-seleniumlibrary
   - robotframework-seleniumscreenshots
+  - robotframeworklexer
   - robotkernel =={{ version }}
   - robotlab =={{ version }}
   {% if platform == "darwin" %}- python.app{% endif %}

--- a/recipes/robotframeworklexer/meta.yaml
+++ b/recipes/robotframeworklexer/meta.yaml
@@ -11,15 +11,14 @@ source:
 
 build:
   number: 0
-  script:
-    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
 
 requirements:
   host:
     - pip
     - python
   run:
-    - six
+    - python
     - pygments
 
 test:

--- a/recipes/robotframeworklexer/meta.yaml
+++ b/recipes/robotframeworklexer/meta.yaml
@@ -13,8 +13,6 @@ build:
   number: 0
   script:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
-  entry_points:
-    - pyshortcut = pyshortcuts:shortcut_cli
 
 requirements:
   host:
@@ -27,7 +25,6 @@ requirements:
 test:
   imports:
     - robotframeworklexer
-
 
 about:
   home: https://github.com/robotframework/pygmentslexer

--- a/recipes/robotframeworklexer/meta.yaml
+++ b/recipes/robotframeworklexer/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "robotframeworklexer" %}
+{% set version = "1.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ddd3ea50b54b47aee86a83c400534a61e2588dec875a3c10f04822280e834b8f
+
+build:
+  number: 0
+  script:
+    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
+  entry_points:
+    - pyshortcut = pyshortcuts:shortcut_cli
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - six
+    - pygments
+
+test:
+  imports:
+    - robotframeworklexer
+
+
+about:
+  home: https://github.com/robotframework/pygmentslexer
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE.txt
+  summary: >
+    This project implements a Pygments lexer for Robot Framework test data in
+    plain text format.

--- a/robotlab/src/robotlab/launch.py
+++ b/robotlab/src/robotlab/launch.py
@@ -15,10 +15,16 @@ from robotlab import WIN, BIN_DIR, SCRIPT_EXT
 
 
 ACTIVATE = [
-    f'''"{BIN_DIR}\\activate"  "{sys.prefix}"  || activate "{sys.prefix}"'''
+    f'''call "{BIN_DIR}\\activate"  "{sys.prefix}"  || activate "{sys.prefix}"'''
 ] if WIN else [
     "#!" + "/usr/bin/env bash",
     f'''. "{BIN_DIR}/activate" "{sys.prefix}" || . activate "{sys.prefix}"'''
+]
+
+CMD = [
+    "call python -m robotlab.labapp"
+] if WIN else [
+    "pyton -m robotlab.labapp"
 ]
 
 
@@ -26,14 +32,13 @@ def launch_robotlab():
     with TemporaryDirectory() as td:
         tdp = Path(td)
         script = tdp / f"launch_robotlab.{SCRIPT_EXT}"
-        lines = ACTIVATE + ["python -m robotlab.labapp"]
+        lines = ACTIVATE + CMD
         script.write_text(os.linesep.join(lines))
         script.chmod(0o755)
         print(script.read_text(), "\n")
         proc = subprocess.Popen(
             [str(script)],
-            cwd=os.path.expanduser("~"),
-            preexec_fn=os.setsid
+            cwd=os.path.expanduser("~")
         )
         try:
             proc.wait()

--- a/robotlab/src/robotlab/launch.py
+++ b/robotlab/src/robotlab/launch.py
@@ -32,7 +32,7 @@ def launch_robotlab():
         print(script.read_text(), "\n")
         proc = subprocess.Popen(
             [str(script)],
-            cwd=os.environ["HOME"],
+            cwd=os.path.expanduser("~"),
             preexec_fn=os.setsid
         )
         try:

--- a/robotlab/src/robotlab/launch.py
+++ b/robotlab/src/robotlab/launch.py
@@ -11,7 +11,7 @@ import signal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from . import WIN, BIN_DIR, SCRIPT_EXT
+from robotlab import WIN, BIN_DIR, SCRIPT_EXT
 
 
 ACTIVATE = [

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -88,6 +88,7 @@ def build_constructor():
         cd_version=CHROMEDRIVER_VERSION,
         ipyw_version=IPYWIDGETS_VERSION,
         script_ext=SCRIPT_EXT,
+        platform=PLATFORM,
     )
 
     CONSTRUCT.write_text(construct)


### PR DESCRIPTION
Fixes #17 

Pyshortcuts launches with the form `c:\robotlab\python.exe c:\robotlab\Lib\site-packages\robotlab\launch.py`, so launch can't have relative imports.