### PR TITLE
Automate release to GitHub from Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,14 @@ jobs:
     name: Linux
     vmImage: ubuntu-16.04
 
+- template: ci/job.deploy.yml
+  parameters:
+    name: Linux
+    vmImage: ubuntu-16.04
+    githubConnection: robots-from-jupyter
+    repositoryName: robots-from-jupyter/robotlab
+    artifact: RobotLab
+
 trigger: [master]
 
 pr: [master]

--- a/ci/job.deploy.yml
+++ b/ci/job.deploy.yml
@@ -31,10 +31,10 @@ jobs:
           downloadPath: _artifacts/constructor
       - script: find _artifacts
         displayName: List Installers
-      - task: GithubRelease@0
-        inputs:
-          githubConnection: ${{ parameters.githubConnection }}
-          repositoryName: ${{ parameters.repositoryName }}
-          action: create
-          tagSource: auto
-          assets: _artifacts/constructor
+      # - task: GithubRelease@0
+      #   inputs:
+      #     githubConnection: ${{ parameters.githubConnection }}
+      #     repositoryName: ${{ parameters.repositoryName }}
+      #     action: create
+      #     tagSource: auto
+      #     assets: _artifacts/constructor

--- a/ci/job.deploy.yml
+++ b/ci/job.deploy.yml
@@ -1,0 +1,40 @@
+parameters:
+  name: Linux
+  vmImage: ubuntu-16.04
+  githubConnection: robots-from-jupyter
+  repositoryName: robots-from-jupyter/robotlab
+  artifact: RobotLab
+
+jobs:
+  - job: Deploy
+    pool:
+      vmImage: ${{ parameters.vmImage }}
+    dependsOn:
+      - Linux
+      - MacOSX
+      - Windows
+    steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: Fetch OSX Installer
+        inputs:
+          artifactName: ${{ parameters.artifact }} For Linux
+          downloadPath: _artifacts/constructor
+      - task: DownloadBuildArtifacts@0
+        displayName: Fetch OSX Installer
+        inputs:
+          artifactName: ${{ parameters.artifact }} For OSX
+          downloadPath: _artifacts/constructor
+      - task: DownloadBuildArtifacts@0
+        displayName: Fetch Windows Installer
+        inputs:
+          artifactName: ${{ parameters.artifact }} For Windows
+          downloadPath: _artifacts/constructor
+      - script: find _artifacts
+        displayName: List Installers
+      - task: GithubRelease@0
+        inputs:
+          githubConnection: ${{ parameters.githubConnection }}
+          repositoryName: ${{ parameters.repositoryName }}
+          action: create
+          tagSource: auto
+          assets: _artifacts/constructor

--- a/ci/job.deploy.yml
+++ b/ci/job.deploy.yml
@@ -15,14 +15,14 @@ jobs:
       - Windows
     steps:
       - task: DownloadBuildArtifacts@0
-        displayName: Fetch OSX Installer
+        displayName: Fetch Linux Installer
         inputs:
           artifactName: ${{ parameters.artifact }} For Linux
           downloadPath: _artifacts/constructor
       - task: DownloadBuildArtifacts@0
-        displayName: Fetch OSX Installer
+        displayName: Fetch MacOSX Installer
         inputs:
-          artifactName: ${{ parameters.artifact }} For OSX
+          artifactName: ${{ parameters.artifact }} For MacOSX
           downloadPath: _artifacts/constructor
       - task: DownloadBuildArtifacts@0
         displayName: Fetch Windows Installer


### PR DESCRIPTION
for #16

The goal is to get to where adding a tag in the github UI will touch off a build and upload the installers when they are ready.

This will be a bit rocky, and may not be completed today.