### PR TITLE
Attempt draft release from CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,9 @@
-trigger: [master]
+trigger:
+  batch: true
+  branches:
+    include:
+      - master
+      - refs/tags/v*
 
 pr: [master]
 
@@ -49,3 +54,4 @@ jobs:
 
   # group 3: reporting, etc
   - template: ci/job.combine.yml
+  - template: ci/job.release.yml

--- a/ci/job.release.yml
+++ b/ci/job.release.yml
@@ -1,0 +1,42 @@
+parameters:
+  name: Linux
+  vmImage: ubuntu-16.04
+  githubConnection: robots-from-jupyter
+  repositoryName: robots-from-jupyter/robotlab
+  artifact: RobotLab
+
+jobs:
+  - job: Deploy
+    pool:
+      vmImage: ${{ parameters.vmImage }}
+    dependsOn:
+      - LinuxTest
+      - MacOSXTest
+      - WindowsTest
+      - conda_win_test
+      - conda_noarch_test
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: Fetch Linux Installer
+        inputs:
+          artifactName: ${{ parameters.artifact }} For Linux
+          downloadPath: _artifacts/constructor
+      - task: DownloadBuildArtifacts@0
+        displayName: Fetch MacOSX Installer
+        inputs:
+          artifactName: ${{ parameters.artifact }} For MacOSX
+          downloadPath: _artifacts/constructor
+      - task: DownloadBuildArtifacts@0
+        displayName: Fetch Windows Installer
+        inputs:
+          artifactName: ${{ parameters.artifact }} For Windows
+          downloadPath: _artifacts/constructor
+      - script: cd _artifacts/constructor && sha256sum * >> SHA256SUMS
+        displayName: build hashes
+      - task: GithubRelease@0
+        inputs:
+          githubConnection: ${{ parameters.githubConnection }}
+          repositoryName: ${{ parameters.repositoryName }}
+          assets: _artifacts/constructor
+          isDraft: true

--- a/ci/job.release.yml
+++ b/ci/job.release.yml
@@ -1,7 +1,7 @@
 parameters:
   name: Linux
   vmImage: ubuntu-16.04
-  githubConnection: robots-from-jupyter
+  githubConnection: release-robots-from-jupyter
   repositoryName: robots-from-jupyter/robotlab
   artifact: RobotLab
 


### PR DESCRIPTION
Probably still have some other stuff to do before releasing `2019.9.0`, but figured I'd get this going.

- [ ] show a draft [release](https://github.com/robots-from-jupyter/robotlab/releases) gets built when a tag is created
  - [ ] should include lin/win/osx installers
  - [ ] should include a `SHA26SUMS` file
  - [ ] should have some notes
  - [ ] anything else?

I intend to still do manual testing before promoting it the release out of draft, at least for the time being.

For #16. 