### PR TITLE
try turning off ignore_duplicate_files

### DIFF
--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -49,15 +49,15 @@ commands:
     env_spec: robotlab-dev
 
 channels:
-- https://conda.anaconda.org/anaconda
 - https://conda.anaconda.org/conda-forge
+- https://conda.anaconda.org/anaconda
 
 env_specs:
   _robots_from_jupyter:
     description: the main build/test environment
     channels:
-    - https://conda.anaconda.org/anaconda
     - https://conda.anaconda.org/conda-forge
+    - https://conda.anaconda.org/anaconda
     packages:
       - conda >=4.7.12,<4.8
       - conda-build >=3.18.9,<3.19

--- a/ci/env-combine.yml
+++ b/ci/env-combine.yml
@@ -1,8 +1,8 @@
 name: robotlab-combine
 
 channels:
-  - https://conda.anaconda.org/anaconda
   - https://conda.anaconda.org/conda-forge
+  - https://conda.anaconda.org/anaconda
 
 dependencies:
   - robotframework

--- a/ci/env-lab.yml
+++ b/ci/env-lab.yml
@@ -1,8 +1,8 @@
 name: robotlab-lab
 
 channels:
-  - https://conda.anaconda.org/anaconda
   - https://conda.anaconda.org/conda-forge
+  - https://conda.anaconda.org/anaconda
 
 dependencies:
   - black

--- a/ci/env-main.yml
+++ b/ci/env-main.yml
@@ -1,8 +1,8 @@
 name: robotlab-main
 
 channels:
-  - https://conda.anaconda.org/anaconda
   - https://conda.anaconda.org/conda-forge
+  - https://conda.anaconda.org/anaconda
 
 dependencies:
   - conda >=4.7.12,<4.8

--- a/constructor/construct.yaml.in
+++ b/constructor/construct.yaml.in
@@ -11,8 +11,8 @@ channels_remap:
 
 channels:
   - {{ build_channel }}
-  - https://conda.anaconda.org/anaconda
   - https://conda.anaconda.org/conda-forge
+  - https://conda.anaconda.org/anaconda
 
 specs:
   - python >={{ py_min }},<{{ py_max }}

--- a/constructor/construct.yaml.in
+++ b/constructor/construct.yaml.in
@@ -3,7 +3,6 @@ version: {{ version }}
 company: Robots from Jupyter
 post_install: post_install.bat  [win]
 post_install: post_install.sh  [unix]
-ignore_duplicate_files: True
 license_file: ../LICENSE
 
 channels_remap:

--- a/constructor/construct.yaml.in
+++ b/constructor/construct.yaml.in
@@ -3,6 +3,8 @@ version: {{ version }}
 company: Robots from Jupyter
 post_install: post_install.bat  [win]
 post_install: post_install.sh  [unix]
+# hopefully we can keep this on, but sometimes...
+# ignore_duplicate_files: True
 license_file: ../LICENSE
 
 channels_remap:

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,8 @@
 name: _robots_from_jupyter
 
 channels:
-  - https://conda.anaconda.org/anaconda
   - https://conda.anaconda.org/conda-forge
+  - https://conda.anaconda.org/anaconda
 
 dependencies:
   - conda >=4.7.12,<4.8

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -53,9 +53,9 @@ CONDA_BUILD_ARGS = [
     "--cache-dir",
     CONDA_CACHE,
     "-c",
-    "https://conda.anaconda.org/anaconda",
-    "-c",
     "https://conda.anaconda.org/conda-forge",
+    "-c",
+    "https://conda.anaconda.org/anaconda",
     "--python",
     PY_MIN,
 ]


### PR DESCRIPTION
Firefox was fixed in conda-forge, which is, i believe, the only reason we had `ignore_duplicate_files` in there. It's useful for making sure we don't have clobbery packages, but is _usually_ okay to leave on.